### PR TITLE
hotfix/allow for backwards compatibility (3.5)

### DIFF
--- a/signalr_aio/transports/_transport.py
+++ b/signalr_aio/transports/_transport.py
@@ -4,6 +4,12 @@
 # signalr_aio/transports/_transport.py
 # Stanislav Lazarov
 
+# python compatiblity for <3.6
+try:
+    ModuleNotFoundError
+except NameError:
+    ModuleNotFoundError = ImportError
+
 # -----------------------------------
 # Internal Imports
 from ._exceptions import ConnectionClosed


### PR DESCRIPTION
This fixes the issue raised [here](https://github.com/slazarov/python-signalr-client/issues/12) with backwards compatibility.

It would great if this could be merged and released in a new version.