### PR TITLE
Unwrap data on invoke when only one element exists

### DIFF
--- a/signalr_aio/hubs/_hub.py
+++ b/signalr_aio/hubs/_hub.py
@@ -22,7 +22,7 @@ class HubServer:
         message = {
             'H': self.name,
             'M': method,
-            'A': data,
+            'A': data[0] if len(data) == 1 else data,
             'I': self.__connection.increment_send_counter()
         }
         self.__connection.send(message)


### PR DESCRIPTION
When invoke is called with only one data element this element needs to be unwrapped.
Otherwise the server is not able to deconstruct a JSON serialized object when this is the data to be send.